### PR TITLE
Umstellung auf Java8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ configurations {
 
 sourceCompatibility = JavaVersion.VERSION_1_8 
 targetCompatibility = JavaVersion.VERSION_1_8
-compileJava.options.encoding = 'UTF-8'
+compileJava.options.encoding = 'US-ASCII'
 
 dependencies {
     compile(group: 'org.geotools', name: 'gt-shapefile', version: '10.8') {

--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,9 @@ configurations {
 //    resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
 //}
 
-sourceCompatibility = "1.6" 
-targetCompatibility = "1.6"
-compileJava.options.encoding = 'US-ASCII'
+sourceCompatibility = JavaVersion.VERSION_1_8 
+targetCompatibility = JavaVersion.VERSION_1_8
+compileJava.options.encoding = 'UTF-8'
 
 dependencies {
     compile(group: 'org.geotools', name: 'gt-shapefile', version: '10.8') {


### PR DESCRIPTION
Source- und Targetcompatibility ist neu Java 8. 

`compileJava.options.encoding` habe ich auf UTF-8 gesetzt. Da bin ich aber unsicher, ob das überhaupt notwendig ist. Jedenfalls hat es bei mir mit `US-ASCII` nicht kompiliert, wenn ein Umlaut in einem Kommentar vorkam. Ich bin davon ausgegangen, dass das so nicht wirklich gewollt ist.