### PR TITLE
[ShapeWriter] trim attribute names if they are too long

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,10 @@ dependencies {
         exclude group: 'com.vividsolutions', module: 'jts' // use version that iox-ili depends on
     }
     testCompile group: 'junit', name: 'junit', version: '4.+'
-    compile group: 'ch.interlis', name: 'iox-ili', version: '1.20.7'
+    compile('ch.interlis:iox-ili:1.20.7') {
+        exclude group: 'ch.ehi', module: 'ehibasics'
+    }
+    compile group: 'ch.ehi', name: 'ehibasics', version: '1.3.1-SNAPSHOT'
     compile group: 'ch.interlis', name: 'ili2c-tool', version: '5.0.6'
 	compile group: 'net.iharder', name: 'base64', version: '2.3.9'
     runtime group: 'org.xerial', name: 'sqlite-jdbc', version: '3.21.0.1'

--- a/src/test/data/ShapeWriter/Test1.ili
+++ b/src/test/data/ShapeWriter/Test1.ili
@@ -20,6 +20,13 @@ MODEL Test1 (de) AT "mailto:ceis@localhost" VERSION "20170703" =
 			attrPoint2 : Lkoord;
 		END Point2;
 		
+        CLASS Point3 =
+            id1 : 0 .. 150;
+            SehrLangerText : TEXT*100;
+            Double : 0 .. 60000;
+            attrPoint2 : Lkoord;
+        END Point3;
+		
 		CLASS MultiPoint =
 			attrMPoint : Lkoord;
 		END MultiPoint;

--- a/src/test/java/ch/interlis/ioxwkf/dbtools/Db2ShpTest.java
+++ b/src/test/java/ch/interlis/ioxwkf/dbtools/Db2ShpTest.java
@@ -2165,7 +2165,8 @@ public class Db2ShpTest {
                 if(featureCollectionIter.hasNext()) {
                     // feature object
                     SimpleFeature shapeObj=(SimpleFeature) featureCollectionIter.next();
-                    Object attr1=shapeObj.getAttribute("sehrlanger");
+                    System.out.println(shapeObj.toString());
+                    Object attr1=shapeObj.getAttribute("sehrltnmen");
                     assertEquals(attr1.toString(), "abc");
                     Object attr2=shapeObj.getAttribute(ShapeReader.GEOTOOLS_THE_GEOM);
                     assertEquals(attr2.toString(), "POINT (-0.2285714285714285 0.5688311688311687)");

--- a/src/test/java/ch/interlis/ioxwkf/shp/ShapeWriterTest.java
+++ b/src/test/java/ch/interlis/ioxwkf/shp/ShapeWriterTest.java
@@ -1384,4 +1384,120 @@ public class ShapeWriterTest {
 	    	}
 		}
 	}
+	
+    // Ueberlange Attributnamen (> 10 Zeichen)
+    // Gekuerzte Attributnamen (substring) waeren gleich. Algorithmus muss 
+    // eindeutige Namen finden.
+    @Test
+    public void similarLongAttributeName_pointAttribute_Ok() throws IoxException, IOException, Ili2cFailure {
+        Iom_jObject inputObj = new Iom_jObject("Test1.Topic1.Point2", "o1");
+        inputObj.setattrvalue("id1", "1");
+        inputObj.setattrvalue("SehrLangerText", "text1");
+        inputObj.setattrvalue("SehrLangerLangerText", "text2");
+        inputObj.setattrvalue("SehrLangerLangerLangerText", "text3");        
+        inputObj.setattrvalue("Double", "53434");
+        IomObject coordValue = inputObj.addattrobj("attrPoint2", "COORD");
+        coordValue.setattrvalue("C1", "-0.4025974025974026");
+        coordValue.setattrvalue("C2", "1.3974025974025972");
+        ShapeWriter writer = null;
+        File file = new File(TEST_OUT, "Point2.shp");
+        try {
+            writer = new ShapeWriter(file);
+            writer.write(new StartTransferEvent());
+            writer.write(new StartBasketEvent("Test1.Topic1", "bid1"));
+            writer.write(new ObjectEvent(inputObj));
+            writer.write(new EndBasketEvent());
+            writer.write(new EndTransferEvent());
+        } finally {
+            if (writer != null) {
+                try {
+                    writer.close();
+                } catch (IoxException e) {
+                    throw new IoxException(e);
+                }
+                writer = null;
+            }
+        }
+        {
+            // Open the file for reading
+            FileDataStore dataStore = FileDataStoreFinder.getDataStore(new java.io.File(TEST_OUT, "Point2.shp"));
+            SimpleFeatureSource featuresSource = dataStore.getFeatureSource();
+            SimpleFeatureIterator featureCollectionIter = featuresSource.getFeatures().features();
+            if (featureCollectionIter.hasNext()) {
+                // feature object
+                SimpleFeature shapeObj = (SimpleFeature) featureCollectionIter.next();
+                
+                Object attr1 = shapeObj.getAttribute("id1");
+                assertEquals("1", attr1.toString());
+                // Die Reihenfolge stimmt nicht mehr mit der Definition des IomObjektes ueberein.
+                // Auf den ersten Blick irritierend. Aber das sollte nicht falsch sein und 
+                // keine Auswirkungen haben.
+                Object attr2 = shapeObj.getAttribute("SehrLanger"); // Shapefile-tauglicher Attributnamen (10 Zeichen)
+                assertEquals("text3", attr2.toString());
+                Object attr3 = shapeObj.getAttribute("SehrLange1"); // Shapefile-tauglicher Attributnamen (9+1 Zeichen)
+                assertEquals("text1", attr3.toString());
+                Object attr4 = shapeObj.getAttribute("SehrLange2"); // Shapefile-tauglicher Attributnamen (9+1 Zeichen)
+                assertEquals("text2", attr4.toString());
+                Object attr5 = shapeObj.getAttribute("Double");
+                assertEquals("53434", attr5.toString());
+                Object attr6 = shapeObj.getAttribute(ShapeReader.GEOTOOLS_THE_GEOM);
+                assertEquals("POINT (-0.4025974025974026 1.3974025974025972)", attr6.toString());
+            }
+            featureCollectionIter.close();
+            dataStore.dispose();
+        }
+    }
+    
+    // Ueberlanger Attributnamen (> 10 Zeichen)
+    // Modell wird gesetzt
+    @Test
+    public void setModel_longAttributeName_pointAttribute_Ok() throws IoxException, IOException, Ili2cFailure {
+        Iom_jObject inputObj = new Iom_jObject("Test1.Topic1.Point3", "o1");
+        inputObj.setattrvalue("id1", "1");
+        inputObj.setattrvalue("SehrLangerText", "text1");
+        inputObj.setattrvalue("Double", "53434");
+        IomObject coordValue = inputObj.addattrobj("attrPoint2", "COORD");
+        coordValue.setattrvalue("C1", "-0.4025974025974026");
+        coordValue.setattrvalue("C2", "1.3974025974025972");
+        ShapeWriter writer = null;
+        File file = new File(TEST_OUT, "Point2.shp");
+        try {
+            writer = new ShapeWriter(file);
+            writer.setModel(td);
+            writer.write(new StartTransferEvent());
+            writer.write(new StartBasketEvent("Test1.Topic1", "bid1"));
+            writer.write(new ObjectEvent(inputObj));
+            writer.write(new EndBasketEvent());
+            writer.write(new EndTransferEvent());
+        } finally {
+            if (writer != null) {
+                try {
+                    writer.close();
+                } catch (IoxException e) {
+                    throw new IoxException(e);
+                }
+                writer = null;
+            }
+        }
+        {
+            // Open the file for reading
+            FileDataStore dataStore = FileDataStoreFinder.getDataStore(new java.io.File(TEST_OUT, "Point2.shp"));
+            SimpleFeatureSource featuresSource = dataStore.getFeatureSource();
+            SimpleFeatureIterator featureCollectionIter = featuresSource.getFeatures().features();
+            if (featureCollectionIter.hasNext()) {
+                // feature object
+                SimpleFeature shapeObj = (SimpleFeature) featureCollectionIter.next();
+                Object attr1 = shapeObj.getAttribute("id1");
+                assertEquals("1", attr1.toString());
+                Object attr2 = shapeObj.getAttribute("SehrLanger"); // Shapefile-tauglicher Attributnamen (10 Zeichen)
+                assertEquals("text1", attr2.toString());
+                Object attr3 = shapeObj.getAttribute("Double");
+                assertEquals("53434", attr3.toString());
+                Object attr4 = shapeObj.getAttribute(ShapeReader.GEOTOOLS_THE_GEOM);
+                assertEquals("POINT (-0.4025974025974026 1.3974025974025972)", attr4.toString());
+            }
+            featureCollectionIter.close();
+            dataStore.dispose();
+        }
+    }
 }

--- a/src/test/java/ch/interlis/ioxwkf/shp/ShapeWriterTest.java
+++ b/src/test/java/ch/interlis/ioxwkf/shp/ShapeWriterTest.java
@@ -999,6 +999,7 @@ public class ShapeWriterTest {
 		if(featureCollectionIter.hasNext()) {
 			// feature object
 			SimpleFeature shapeObj=(SimpleFeature) featureCollectionIter.next();
+			System.out.println(shapeObj.toString());
 			Object attr2=shapeObj.getAttribute(ShapeReader.GEOTOOLS_THE_GEOM);
 			assertEquals("MULTIPOLYGON (((-0.2285714285714285 0.5688311688311687, -0.1585714285714285 0.5888311688311687, -0.1585714285714285 0.5888311688311687, -0.1585714285714285 0.5688311688311687, -0.1585714285714285 0.5688311688311687, -0.2285714285714285 0.5688311688311687)))",attr2.toString());
 		}
@@ -1392,9 +1393,9 @@ public class ShapeWriterTest {
     public void similarLongAttributeName_pointAttribute_Ok() throws IoxException, IOException, Ili2cFailure {
         Iom_jObject inputObj = new Iom_jObject("Test1.Topic1.Point2", "o1");
         inputObj.setattrvalue("id1", "1");
-        inputObj.setattrvalue("SehrLangerText", "text1");
-        inputObj.setattrvalue("SehrLangerLangerText", "text2");
-        inputObj.setattrvalue("SehrLangerLangerLangerText", "text3");        
+        inputObj.setattrvalue("BodenbedeckungArt", "text1");
+        inputObj.setattrvalue("BodenbedeckungPos", "text2");
+        inputObj.setattrvalue("BodenbedeckungDatum", "text3");        
         inputObj.setattrvalue("Double", "53434");
         IomObject coordValue = inputObj.addattrobj("attrPoint2", "COORD");
         coordValue.setattrvalue("C1", "-0.4025974025974026");
@@ -1429,14 +1430,11 @@ public class ShapeWriterTest {
                 
                 Object attr1 = shapeObj.getAttribute("id1");
                 assertEquals("1", attr1.toString());
-                // Die Reihenfolge stimmt nicht mehr mit der Definition des IomObjektes ueberein.
-                // Auf den ersten Blick irritierend. Aber das sollte nicht falsch sein und 
-                // keine Auswirkungen haben.
-                Object attr2 = shapeObj.getAttribute("SehrLanger"); // Shapefile-tauglicher Attributnamen (10 Zeichen)
+                Object attr2 = shapeObj.getAttribute("BodnbgDtum");
                 assertEquals("text3", attr2.toString());
-                Object attr3 = shapeObj.getAttribute("SehrLange1"); // Shapefile-tauglicher Attributnamen (9+1 Zeichen)
+                Object attr3 = shapeObj.getAttribute("BodnbngArt");
                 assertEquals("text1", attr3.toString());
-                Object attr4 = shapeObj.getAttribute("SehrLange2"); // Shapefile-tauglicher Attributnamen (9+1 Zeichen)
+                Object attr4 = shapeObj.getAttribute("BodnbngPos");
                 assertEquals("text2", attr4.toString());
                 Object attr5 = shapeObj.getAttribute("Double");
                 assertEquals("53434", attr5.toString());
@@ -1489,7 +1487,7 @@ public class ShapeWriterTest {
                 SimpleFeature shapeObj = (SimpleFeature) featureCollectionIter.next();
                 Object attr1 = shapeObj.getAttribute("id1");
                 assertEquals("1", attr1.toString());
-                Object attr2 = shapeObj.getAttribute("SehrLanger"); // Shapefile-tauglicher Attributnamen (10 Zeichen)
+                Object attr2 = shapeObj.getAttribute("SehrLrText"); // Shapefile-tauglicher Attributnamen (10 Zeichen)
                 assertEquals("text1", attr2.toString());
                 Object attr3 = shapeObj.getAttribute("Double");
                 assertEquals("53434", attr3.toString());


### PR DESCRIPTION
Attributnamen werden beim Shapefile-Export auf die maximal zulässige Länge gekürzt, falls sie zu lang sind. Kollisionen werden aufgelöst, indem zusätzlich eine Zahl an den Namen gehängt wird. Dies ist aber nicht endlos möglich (max. 10). Der Algorithmus könnte natürlich noch viel schlauer gemacht werden bei Bedarf.
