### PR TITLE
make trimmed shapefile attribute names unique

### DIFF
--- a/src/main/java/ch/interlis/ioxwkf/shp/ShapeWriter.java
+++ b/src/main/java/ch/interlis/ioxwkf/shp/ShapeWriter.java
@@ -256,7 +256,7 @@ public class ShapeWriter implements ch.interlis.iox.IoxWriter {
 	    					attributeBuilder.setMaxOccurs(1);
 	    					attributeBuilder.setNillable(true);
 	    					//build the descriptor
-                            String trimmedAttrName = trimAttributeName(attrName,10);
+                            String trimmedAttrName = trimAttributeName(attrName,9);
                             AttributeDescriptor descriptor = attributeBuilder.buildDescriptor(trimmedAttrName);                            
 	    					// add descriptor to descriptor map
                             addAttrDesc(attrName, descriptor);      
@@ -335,7 +335,7 @@ public class ShapeWriter implements ch.interlis.iox.IoxWriter {
     					attributeBuilder.setMaxOccurs(1);
     					attributeBuilder.setNillable(true);
     					//build the descriptor
-                        String trimmedAttrName = trimAttributeName(attrName,10);
+                        String trimmedAttrName = trimAttributeName(attrName,9);
                         AttributeDescriptor descriptor = attributeBuilder.buildDescriptor(trimmedAttrName);                            
     					addAttrDesc(attrName, descriptor);  
             		}
@@ -674,7 +674,7 @@ public class ShapeWriter implements ch.interlis.iox.IoxWriter {
 	 * @throws IoxException 
 	 */
 	public void setAttributeDescriptors(AttributeDescriptor attrDescs[]) throws IoxException {
-        initAttrDescs(); 
+	    initAttrDescs(); 
         for(AttributeDescriptor attrDesc:attrDescs) {
             if(attrDesc.getType() instanceof GeometryType) {
                 iliGeomAttrName=attrDesc.getLocalName();
@@ -691,7 +691,7 @@ public class ShapeWriter implements ch.interlis.iox.IoxWriter {
             attributeBuilder.setMaxOccurs(1);
             attributeBuilder.setNillable(true);
             
-            String trimmedAttrName = trimAttributeName(attrDesc.getLocalName(),10);
+            String trimmedAttrName = trimAttributeName(attrDesc.getLocalName(),9);
             AttributeDescriptor descriptor = attributeBuilder.buildDescriptor(trimmedAttrName);                            
 
             addAttrDesc(attrDesc.getLocalName(), descriptor);
@@ -706,6 +706,11 @@ public class ShapeWriter implements ch.interlis.iox.IoxWriter {
         attrDescs.add(descriptor);
         attrDescsMap.put(originalAttrName, descriptor);
     }
+    
+    private boolean existsAttrName(String attrName) {        
+        return attrDescs.stream().anyMatch(s -> s.getLocalName().equals(attrName)) ? true : false;
+    }
+
 	
     private String trimAttributeName(String attrName, int maxlen) {           
         // Geometry attribute names do not need to be trimmed,
@@ -713,6 +718,18 @@ public class ShapeWriter implements ch.interlis.iox.IoxWriter {
         if (attrName.length() <= maxlen || attrName.equalsIgnoreCase(iliGeomAttrName)) {
             return attrName;
         }
-        return NameUtility.shortcutName(attrName,maxlen);
+        
+        String trimmedAttrName = NameUtility.shortcutName(attrName,maxlen);
+
+        // Sehr aehnliche Attributnamen koennen nach dem Kuerzen
+        // gleich sein und muessen nochmals angepasst werden.
+        // Funktioniert bis maximal c=9. Bei c>9 ist die Laenge
+        // des Namens > 10 und nicht mehr Shapefile-konform.
+        String base=trimmedAttrName;
+        int c=1;
+        while(existsAttrName(trimmedAttrName)){
+            trimmedAttrName=base+Integer.toString(c++);
+        }
+        return trimmedAttrName;
     }
 }

--- a/src/test/java/ch/interlis/ioxwkf/dbtools/Db2ShpTest.java
+++ b/src/test/java/ch/interlis/ioxwkf/dbtools/Db2ShpTest.java
@@ -2166,7 +2166,7 @@ public class Db2ShpTest {
                     // feature object
                     SimpleFeature shapeObj=(SimpleFeature) featureCollectionIter.next();
                     System.out.println(shapeObj.toString());
-                    Object attr1=shapeObj.getAttribute("sehrltnmen");
+                    Object attr1=shapeObj.getAttribute("sehrtnmen");
                     assertEquals(attr1.toString(), "abc");
                     Object attr2=shapeObj.getAttribute(ShapeReader.GEOTOOLS_THE_GEOM);
                     assertEquals(attr2.toString(), "POINT (-0.2285714285714285 0.5688311688311687)");

--- a/src/test/java/ch/interlis/ioxwkf/shp/ShapeWriterTest.java
+++ b/src/test/java/ch/interlis/ioxwkf/shp/ShapeWriterTest.java
@@ -1386,20 +1386,22 @@ public class ShapeWriterTest {
 		}
 	}
 	
-    // Ueberlange Attributnamen (> 10 Zeichen)
-    // Gekuerzte Attributnamen (substring) waeren gleich. Algorithmus muss 
-    // eindeutige Namen finden.
-    @Test
-    public void similarLongAttributeName_pointAttribute_Ok() throws IoxException, IOException, Ili2cFailure {
+	
+	// Ueberlange Attributnamen (> 10 Zeichen)
+	// Algorithmus alleine (NameUtility.shortcutName()) kann doch wieder
+	// zu Namenskonflikten fuehren. Aus diesem Grund muessen nach dem
+	// Kuerzen alle zusammen betrachtet werden.
+	@Test
+	public void verySimilarLongAttributName_pointAttribute_Ok() throws IoxException, IOException {
         Iom_jObject inputObj = new Iom_jObject("Test1.Topic1.Point2", "o1");
         inputObj.setattrvalue("id1", "1");
-        inputObj.setattrvalue("BodenbedeckungArt", "text1");
-        inputObj.setattrvalue("BodenbedeckungPos", "text2");
-        inputObj.setattrvalue("BodenbedeckungDatum", "text3");        
+        inputObj.setattrvalue("ino2_2020_range", "text1");
+        inputObj.setattrvalue("ino2_2010_range", "text2");
         inputObj.setattrvalue("Double", "53434");
         IomObject coordValue = inputObj.addattrobj("attrPoint2", "COORD");
         coordValue.setattrvalue("C1", "-0.4025974025974026");
         coordValue.setattrvalue("C2", "1.3974025974025972");
+
         ShapeWriter writer = null;
         File file = new File(TEST_OUT, "Point2.shp");
         try {
@@ -1419,6 +1421,7 @@ public class ShapeWriterTest {
                 writer = null;
             }
         }
+
         {
             // Open the file for reading
             FileDataStore dataStore = FileDataStoreFinder.getDataStore(new java.io.File(TEST_OUT, "Point2.shp"));
@@ -1430,11 +1433,69 @@ public class ShapeWriterTest {
                 
                 Object attr1 = shapeObj.getAttribute("id1");
                 assertEquals("1", attr1.toString());
-                Object attr2 = shapeObj.getAttribute("BodnbgDtum");
+                Object attr2 = shapeObj.getAttribute("ino2_rnge");
+                assertEquals("text1", attr2.toString());
+                Object attr3 = shapeObj.getAttribute("ino2_rnge1");
+                assertEquals("text2", attr3.toString());
+                Object attr5 = shapeObj.getAttribute("Double");
+                assertEquals("53434", attr5.toString());
+                Object attr6 = shapeObj.getAttribute(ShapeReader.GEOTOOLS_THE_GEOM);
+                assertEquals("POINT (-0.4025974025974026 1.3974025974025972)", attr6.toString());
+            }
+            featureCollectionIter.close();
+            dataStore.dispose();
+        }
+	}
+	
+    // Ueberlange Attributnamen (> 10 Zeichen)
+    // Gekuerzte Attributnamen (substring) waeren gleich. Algorithmus muss 
+    // eindeutige Namen finden.
+    @Test
+    public void similarLongAttributeName_pointAttribute_Ok() throws IoxException, IOException, Ili2cFailure {
+        Iom_jObject inputObj = new Iom_jObject("Test1.Topic1.Point2", "o1");
+        inputObj.setattrvalue("id1", "1");
+        inputObj.setattrvalue("BodenbedeckungArt", "text1");
+        inputObj.setattrvalue("BodenbedeckungPos", "text2");
+        inputObj.setattrvalue("BodenbedeckungDatum", "text3");        
+        inputObj.setattrvalue("Double", "53434");
+        IomObject coordValue = inputObj.addattrobj("attrPoint2", "COORD");
+        coordValue.setattrvalue("C1", "-0.4025974025974026");
+        coordValue.setattrvalue("C2", "1.3974025974025972");
+        ShapeWriter writer = null;
+        File file = new File(TEST_OUT, "Point2a.shp");
+        try {
+            writer = new ShapeWriter(file);
+            writer.write(new StartTransferEvent());
+            writer.write(new StartBasketEvent("Test1.Topic1", "bid1"));
+            writer.write(new ObjectEvent(inputObj));
+            writer.write(new EndBasketEvent());
+            writer.write(new EndTransferEvent());
+        } finally {
+            if (writer != null) {
+                try {
+                    writer.close();
+                } catch (IoxException e) {
+                    throw new IoxException(e);
+                }
+                writer = null;
+            }
+        }
+        {
+            // Open the file for reading
+            FileDataStore dataStore = FileDataStoreFinder.getDataStore(new java.io.File(TEST_OUT, "Point2a.shp"));
+            SimpleFeatureSource featuresSource = dataStore.getFeatureSource();
+            SimpleFeatureIterator featureCollectionIter = featuresSource.getFeatures().features();
+            if (featureCollectionIter.hasNext()) {
+                // feature object
+                SimpleFeature shapeObj = (SimpleFeature) featureCollectionIter.next();
+                
+                Object attr1 = shapeObj.getAttribute("id1");
+                assertEquals("1", attr1.toString());
+                Object attr2 = shapeObj.getAttribute("BodngDtum");
                 assertEquals("text3", attr2.toString());
-                Object attr3 = shapeObj.getAttribute("BodnbngArt");
+                Object attr3 = shapeObj.getAttribute("BodnngArt");
                 assertEquals("text1", attr3.toString());
-                Object attr4 = shapeObj.getAttribute("BodnbngPos");
+                Object attr4 = shapeObj.getAttribute("BodnngPos");
                 assertEquals("text2", attr4.toString());
                 Object attr5 = shapeObj.getAttribute("Double");
                 assertEquals("53434", attr5.toString());
@@ -1487,7 +1548,7 @@ public class ShapeWriterTest {
                 SimpleFeature shapeObj = (SimpleFeature) featureCollectionIter.next();
                 Object attr1 = shapeObj.getAttribute("id1");
                 assertEquals("1", attr1.toString());
-                Object attr2 = shapeObj.getAttribute("SehrLrText"); // Shapefile-tauglicher Attributnamen (10 Zeichen)
+                Object attr2 = shapeObj.getAttribute("SehrrText"); // Shapefile-tauglicher Attributnamen (9 oder 10 Zeichen)
                 assertEquals("text1", attr2.toString());
                 Object attr3 = shapeObj.getAttribute("Double");
                 assertEquals("53434", attr3.toString());


### PR DESCRIPTION
Die Attributnamen wurden getrimmed, um Shapefile-konform zu sein. Das führte zu gleichen Attributnamen, die dann von Geotools automatisch eindeutig gemacht wurden, was wiederum dazu führte, dass die Attributwerte nicht mehr vorhanden waren, da diese - durch Geotools veränderte - Attribute nicht gefunden wurden.

Die Attributenamen werden nun - ähnlich zu ili2db NameMapping.makeSqlTableNameUnique() - eindeutig gemacht.