### PR TITLE
database query option for ExportFromDb (instead of tables only)

### DIFF
--- a/src/main/java/ch/interlis/ioxwkf/dbtools/IoxWkfConfig.java
+++ b/src/main/java/ch/interlis/ioxwkf/dbtools/IoxWkfConfig.java
@@ -22,6 +22,10 @@ public class IoxWkfConfig {
 	/** the data base table name.
 	 */
 	public final static String SETTING_DBTABLE=PREFIX+".dbTable";
+	/** 
+	 * the database sql query
+	 */
+	public final static String SETTING_DBQUERY=PREFIX+".dbQuery";
     public final static String SETTING_GPKGTABLE=PREFIX+".gpkgTable";
 	/** only the listed tables from the database should be exported to the interlis file.
 	 * multiple tables are separated by semicolon (';').


### PR DESCRIPTION
Es ist nun möglich eine beliebige DB-Query zu verwenden, um Daten zu exportieren. Bis jetzt ist es bloss möglich eine Tabelle zu exportieren.

Es gibt eine neue Option in IoxWkfConfig: https://github.com/claeis/iox-wkf/blob/sql-from-db/src/main/java/ch/interlis/ioxwkf/dbtools/IoxWkfConfig.java#L28 
Falls diese fehlt, gilt das alte Verhalten und es wird mindestens eine Tabelle erwartet.

Metainfos über Sachattribute werden mit einer LIMIT 0 Query eruiert. Infos über die Geometrie geht m.E. nur mit LIMIT 1.

Das IomObject erhält einen "Fantasie"-Tag aus Modellnamen, Topicnamen und dem String "native_query_<random 8 Zeichen>". 

