### PR TITLE
[JsonReader] read arrays of simple types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,12 +23,12 @@ dependencies {
         exclude group: 'com.vividsolutions', module: 'jts' // use version that iox-ili depends on
     }
     testCompile group: 'junit', name: 'junit', version: '4.+'
-    compile('ch.interlis:iox-ili:1.21.6') {
+    compile('ch.interlis:iox-ili:1.23.4') {
         exclude group: 'ch.ehi', module: 'ehibasics'
     }
     compile group: 'ch.ehi', name: 'ehibasics', version: '1.4.1'
-    compile group: 'ch.interlis', name: 'ili2c-tool', version: '5.2.2'
-    compile group: 'ch.interlis', name: 'ili2c-core', version: '5.2.2'
+    compile group: 'ch.interlis', name: 'ili2c-tool', version: '5.6.3'
+    compile group: 'ch.interlis', name: 'ili2c-core', version: '5.6.3'
 	compile group: 'net.iharder', name: 'base64', version: '2.3.9'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.9.7'
     runtime group: 'org.xerial', name: 'sqlite-jdbc', version: '3.42.0.0'
@@ -36,10 +36,10 @@ dependencies {
 	testCompile group: 'org.postgresql', name: 'postgresql', version: '42.6.0'
     testCompile group: 'org.testcontainers', name: 'testcontainers', version: '1.18.3'
     testCompile group: 'org.testcontainers', name: 'postgresql', version: '1.18.3'
-	compile('ch.interlis:ili2pg:4.5.1+') {
+	compile('ch.interlis:ili2pg:5.2.2') {
         exclude group: 'ch.interlis', module: 'iox-ili'
     }
-    compile (group: 'ch.interlis', name: 'ili2gpkg', version: '4.5.1+') {
+    compile (group: 'ch.interlis', name: 'ili2gpkg', version: '5.2.2') {
         exclude group: 'ch.interlis', module: 'iox-ili'
     }
 	deployerJars "org.apache.maven.wagon:wagon-ftp:3.0.0"

--- a/src/main/java/ch/interlis/ioxwkf/gpkg/GeoPackageWriter.java
+++ b/src/main/java/ch/interlis/ioxwkf/gpkg/GeoPackageWriter.java
@@ -642,11 +642,11 @@ public class GeoPackageWriter implements IoxWriter {
     	    		pstmt.setObject(i+1, geom);
     	    	} else if (attrDesc.getDbColumnGeomTypeName().equalsIgnoreCase(POLYGON)) {
     	    		jtsGeom = Iox2jts.surface2JTS(iomGeom, 0.00);
-    	    		Object geom = iox2gpgk.surface2wkb(iomGeom, false, 0.00, attrDesc.getSrId());
+    	    		Object geom = iox2gpgk.surface2wkb(iomGeom, false, 0.00, true, attrDesc.getSrId());
     	    		pstmt.setObject(i+1, geom);
     	    	} else if (attrDesc.getDbColumnGeomTypeName().equalsIgnoreCase(MULTIPOLYGON)) {
     	    		jtsGeom = Iox2jts.multisurface2JTS(iomGeom, 0.00, defaultSrsId);
-    	    		Object geom = iox2gpgk.multisurface2wkb(iomGeom, false, 0.00, attrDesc.getSrId());
+    	    		Object geom = iox2gpgk.multisurface2wkb(iomGeom, false, 0.00, true, attrDesc.getSrId());
     	    		pstmt.setObject(i+1, geom);
     	    	}
     	    	

--- a/src/test/data/JsonReader/Test2.ili
+++ b/src/test/data/JsonReader/Test2.ili
@@ -1,0 +1,27 @@
+INTERLIS 2.4;
+
+MODEL Test2 (de) AT "mailto:ceis@localhost" VERSION "20170703" =
+
+    DOMAIN
+    Coord2 = COORD
+      2460000.000 .. 2870000.000,
+      1045000.000 .. 1310000.000,
+      ROTATION 2 -> 1;
+    
+    TOPIC Topic2 =
+    
+        STRUCTURE StructA =
+            attrText : TEXT*60;
+            attrInt : -1000 .. 1000;
+        END StructA;
+
+        CLASS ClassA =
+            attrStruct : StructA;
+            attrBag : BAG OF StructA;
+            attrTextList : LIST {0..*} OF TEXT*5;
+            attrText : TEXT*60;
+        END ClassA;
+    
+    END Topic2;
+    
+END Test2.

--- a/src/test/data/JsonReader/simpleAttrList.json
+++ b/src/test/data/JsonReader/simpleAttrList.json
@@ -1,0 +1,24 @@
+[
+    {
+      "@type": "Test2.Topic2.ClassA",
+      "@id": "o1",
+      "@bid": "bid1",
+      "@topic": "Test2.Topic2",
+      "attrStruct": {
+        "@type": "Test2.Topic2.StructA",
+        "attrText": "lineA"
+      },
+      "attrBag": [
+        {
+          "@type": "Test2.Topic2.StructA",
+          "attrText": "lineB"
+        },
+        {
+          "@type": "Test2.Topic2.StructA",
+          "attrText": "lineC"
+        }
+      ],
+      "attrTextList": ["lineD", "lineE"],
+      "attrText" : "lineF" 
+    }
+]

--- a/src/test/java/ch/interlis/ioxwkf/dbtools/Db2GpkgTest.java
+++ b/src/test/java/ch/interlis/ioxwkf/dbtools/Db2GpkgTest.java
@@ -1964,7 +1964,7 @@ public class Db2GpkgTest {
 		            while (rs.next()) {
 		            	assertEquals("polygon", rs.getString(1));
 		            	IomObject iomGeom = gpkg2iox.read(rs.getBytes(2));
-		            	assertEquals("MULTISURFACE {surface SURFACE {boundary BOUNDARY {polyline POLYLINE {sequence SEGMENTS {segment [COORD {C1 -0.22857142857142854, C2 0.5688311688311687}, COORD {C1 -0.15857142857142853, C2 0.5888311688311687}, COORD {C1 -0.15857142857142853, C2 0.5888311688311687}, COORD {C1 -0.15857142857142853, C2 0.5688311688311687}, COORD {C1 -0.15857142857142853, C2 0.5688311688311687}, COORD {C1 -0.22857142857142854, C2 0.5688311688311687}]}}}}}", 
+		            	assertEquals("MULTISURFACE {surface SURFACE {boundary BOUNDARY {polyline POLYLINE {sequence SEGMENTS {segment [COORD {C1 -0.22857142857142854, C2 0.5688311688311687}, COORD {C1 -0.15857142857142853, C2 0.5888311688311687}, COORD {C1 -0.15857142857142853, C2 0.5688311688311687}, COORD {C1 -0.22857142857142854, C2 0.5688311688311687}]}}}}}", 
 		            			iomGeom.toString());
 		            }
 			        rs.close();
@@ -2037,7 +2037,7 @@ public class Db2GpkgTest {
 		            while (rs.next()) {
 		            	assertEquals("multipolygon", rs.getString(1));
 		            	IomObject iomGeom = gpkg2iox.read(rs.getBytes(2));
-		            	assertEquals("MULTISURFACE {surface SURFACE {boundary BOUNDARY {polyline POLYLINE {sequence SEGMENTS {segment [COORD {C1 -0.228, C2 0.568}, COORD {C1 -0.158, C2 0.588}, COORD {C1 -0.158, C2 0.588}, COORD {C1 -0.158, C2 0.568}, COORD {C1 -0.158, C2 0.568}, COORD {C1 -0.228, C2 0.568}]}}}}}", 
+		            	assertEquals("MULTISURFACE {surface SURFACE {boundary BOUNDARY {polyline POLYLINE {sequence SEGMENTS {segment [COORD {C1 -0.228, C2 0.568}, COORD {C1 -0.158, C2 0.588}, COORD {C1 -0.158, C2 0.568}, COORD {C1 -0.228, C2 0.568}]}}}}}", 
 		            			iomGeom.toString());
 		            }
 			        rs.close();

--- a/src/test/java/ch/interlis/ioxwkf/dbtools/Gpkg2dbTest.java
+++ b/src/test/java/ch/interlis/ioxwkf/dbtools/Gpkg2dbTest.java
@@ -224,7 +224,7 @@ public class Gpkg2dbTest {
                 while(rs.next()){
                     assertEquals(1, rs.getObject(1));
                     assertEquals("12", rs.getObject(2));
-                    assertEquals("SRID=2056;POLYGON((-0.228571428571429 0.568831168831169,-0.158571428571429 0.588831168831169,-0.158571428571429 0.588831168831169,-0.158571428571429 0.568831168831169,-0.158571428571429 0.568831168831169,-0.228571428571429 0.568831168831169))", rs.getObject(3));
+                    assertEquals("SRID=2056;POLYGON((-0.228571428571429 0.568831168831169,-0.158571428571429 0.588831168831169,-0.158571428571429 0.568831168831169,-0.228571428571429 0.568831168831169))", rs.getObject(3));
                 }
             }
         } finally {
@@ -274,8 +274,8 @@ public class Gpkg2dbTest {
                 while(rs.next()){
                     assertTrue(rs.getObject(1).equals(1) || rs.getObject(1).equals(2));
                     assertEquals("12", rs.getObject(2));
-                    assertTrue(rs.getObject(3).equals("SRID=2056;MULTIPOLYGON(((-0.228 0.568,-0.158 0.588,-0.158 0.588,-0.158 0.568,-0.158 0.568,-0.228 0.568)))") ||
-                            (rs.getObject(3).equals("SRID=2056;MULTIPOLYGON(((0.228 1.3,0.158 0.5,0.158 0.5,0.158 1.568,0.158 1.568,0.228 1.3)))")));
+                    assertTrue(rs.getObject(3).equals("SRID=2056;MULTIPOLYGON(((-0.228 0.568,-0.158 0.588,-0.158 0.568,-0.228 0.568)))") ||
+                            (rs.getObject(3).equals("SRID=2056;MULTIPOLYGON(((0.228 1.3,0.158 0.5,0.158 1.568,0.228 1.3)))")));
                 }
             }
         } finally {

--- a/src/test/java/ch/interlis/ioxwkf/dbtools/Shp2dbTest.java
+++ b/src/test/java/ch/interlis/ioxwkf/dbtools/Shp2dbTest.java
@@ -284,7 +284,7 @@ public class Shp2dbTest {
 				assertEquals(2, rsmd.getColumnCount());
 				while(rs.next()){
 					assertEquals("12", rs.getObject(1));
-				  	assertEquals("SRID=2056;POLYGON((-0.228571428571429 0.568831168831169,-0.158571428571429 0.588831168831169,-0.158571428571429 0.588831168831169,-0.158571428571429 0.568831168831169,-0.158571428571429 0.568831168831169,-0.228571428571429 0.568831168831169))", rs.getObject(2));
+				  	assertEquals("SRID=2056;POLYGON((-0.228571428571429 0.568831168831169,-0.158571428571429 0.588831168831169,-0.158571428571429 0.568831168831169,-0.228571428571429 0.568831168831169))", rs.getObject(2));
 				}
 			}
 		}finally{
@@ -336,8 +336,8 @@ public class Shp2dbTest {
 				assertEquals(2, rsmd.getColumnCount());
 				while(rs.next()){
 					assertEquals("12", rs.getObject(1));
-				  	assertTrue(rs.getObject(2).equals("SRID=2056;MULTIPOLYGON(((-0.228 0.568,-0.158 0.588,-0.158 0.588,-0.158 0.568,-0.158 0.568,-0.228 0.568)))") ||
-				  			(rs.getObject(2).equals("SRID=2056;MULTIPOLYGON(((0.228 1.3,0.158 0.5,0.158 0.5,0.158 1.568,0.158 1.568,0.228 1.3)))")));
+				  	assertTrue(rs.getObject(2).equals("SRID=2056;MULTIPOLYGON(((-0.228 0.568,-0.158 0.588,-0.158 0.568,-0.228 0.568)))") ||
+				  			(rs.getObject(2).equals("SRID=2056;MULTIPOLYGON(((0.228 1.3,0.158 0.5,0.158 1.568,0.228 1.3)))")));
 				}
 			}
 		}finally{

--- a/src/test/java/ch/interlis/ioxwkf/gpkg/GeoPackageWriterTest.java
+++ b/src/test/java/ch/interlis/ioxwkf/gpkg/GeoPackageWriterTest.java
@@ -570,7 +570,7 @@ public class GeoPackageWriterTest {
                 rs = stmt.executeQuery("SELECT the_geom FROM class_found_in_last_input_model_ok");
                 while (rs.next()) {
                 	IomObject iomGeom = gpkg2iox.read(rs.getBytes(1));
-                	assertEquals("MULTISURFACE {surface SURFACE {boundary BOUNDARY {polyline POLYLINE {sequence SEGMENTS {segment [COORD {C1 -0.22857142857142854, C2 0.5688311688311687}, COORD {C1 -0.15857142857142853, C2 0.5688311688311687}, COORD {C1 -0.15857142857142853, C2 0.5688311688311687}, COORD {C1 -0.15857142857142853, C2 0.5888311688311687}, COORD {C1 -0.15857142857142853, C2 0.5888311688311687}, COORD {C1 -0.22857142857142854, C2 0.5688311688311687}]}}}}}",
+                	assertEquals("MULTISURFACE {surface SURFACE {boundary BOUNDARY {polyline POLYLINE {sequence SEGMENTS {segment [COORD {C1 -0.22857142857142854, C2 0.5688311688311687}, COORD {C1 -0.15857142857142853, C2 0.5688311688311687}, COORD {C1 -0.15857142857142853, C2 0.5888311688311687}, COORD {C1 -0.22857142857142854, C2 0.5688311688311687}]}}}}}",
                 			iomGeom.toString());
                 }
                 rs.close();
@@ -1304,7 +1304,7 @@ public class GeoPackageWriterTest {
 	            rs = stmt.executeQuery("SELECT attrpolygon FROM polygon");
 	            while (rs.next()) {
 	            	IomObject iomGeom = gpkg2iox.read(rs.getBytes(1));
-	            	assertEquals("MULTISURFACE {surface SURFACE {boundary BOUNDARY {polyline POLYLINE {sequence SEGMENTS {segment [COORD {C1 -0.22857142857142854, C2 0.5688311688311687}, COORD {C1 -0.15857142857142853, C2 0.5688311688311687}, COORD {C1 -0.15857142857142853, C2 0.5688311688311687}, COORD {C1 -0.15857142857142853, C2 0.5888311688311687}, COORD {C1 -0.15857142857142853, C2 0.5888311688311687}, COORD {C1 -0.22857142857142854, C2 0.5688311688311687}]}}}}}",
+	            	assertEquals("MULTISURFACE {surface SURFACE {boundary BOUNDARY {polyline POLYLINE {sequence SEGMENTS {segment [COORD {C1 -0.22857142857142854, C2 0.5688311688311687}, COORD {C1 -0.15857142857142853, C2 0.5688311688311687}, COORD {C1 -0.15857142857142853, C2 0.5888311688311687}, COORD {C1 -0.22857142857142854, C2 0.5688311688311687}]}}}}}",
 	            			iomGeom.toString());
 	            }
 	            rs.close();
@@ -1396,7 +1396,7 @@ public class GeoPackageWriterTest {
 	            rs = stmt.executeQuery("SELECT attrpolygon2, attr1pg, attr2pg FROM polygon_2");
 	            while (rs.next()) {
 	            	IomObject iomGeom = gpkg2iox.read(rs.getBytes(1));
-	            	assertEquals("MULTISURFACE {surface SURFACE {boundary BOUNDARY {polyline POLYLINE {sequence SEGMENTS {segment [COORD {C1 -0.22857142857142854, C2 0.5688311688311687}, COORD {C1 -0.15857142857142853, C2 0.5688311688311687}, COORD {C1 -0.15857142857142853, C2 0.5688311688311687}, COORD {C1 -0.15857142857142853, C2 0.5888311688311687}, COORD {C1 -0.15857142857142853, C2 0.5888311688311687}, COORD {C1 -0.22857142857142854, C2 0.5688311688311687}]}}}}}",
+	            	assertEquals("MULTISURFACE {surface SURFACE {boundary BOUNDARY {polyline POLYLINE {sequence SEGMENTS {segment [COORD {C1 -0.22857142857142854, C2 0.5688311688311687}, COORD {C1 -0.15857142857142853, C2 0.5688311688311687}, COORD {C1 -0.15857142857142853, C2 0.5888311688311687}, COORD {C1 -0.22857142857142854, C2 0.5688311688311687}]}}}}}",
 	            			iomGeom.toString());
 	            	assertEquals("text2", rs.getString(2));
 	            	assertEquals(6, rs.getInt(3));
@@ -1524,7 +1524,7 @@ public class GeoPackageWriterTest {
 	            rs = stmt.executeQuery("SELECT attrmultipolygon FROM multipolygon");
 	            while (rs.next()) {
 	            	IomObject iomGeom = gpkg2iox.read(rs.getBytes(1));
-	            	assertEquals("MULTISURFACE {surface [SURFACE {boundary BOUNDARY {polyline POLYLINE {sequence SEGMENTS {segment [COORD {C1 -0.228, C2 0.568}, COORD {C1 -0.158, C2 0.568}, COORD {C1 -0.158, C2 0.568}, COORD {C1 -0.158, C2 0.588}, COORD {C1 -0.158, C2 0.588}, COORD {C1 -0.228, C2 0.568}]}}}}, SURFACE {boundary BOUNDARY {polyline POLYLINE {sequence SEGMENTS {segment [COORD {C1 0.228, C2 1.3}, COORD {C1 0.158, C2 1.568}, COORD {C1 0.158, C2 1.568}, COORD {C1 0.158, C2 0.5}, COORD {C1 0.158, C2 0.5}, COORD {C1 0.228, C2 1.3}]}}}}]}",
+	            	assertEquals("MULTISURFACE {surface [SURFACE {boundary BOUNDARY {polyline POLYLINE {sequence SEGMENTS {segment [COORD {C1 -0.228, C2 0.568}, COORD {C1 -0.158, C2 0.568}, COORD {C1 -0.158, C2 0.588}, COORD {C1 -0.228, C2 0.568}]}}}}, SURFACE {boundary BOUNDARY {polyline POLYLINE {sequence SEGMENTS {segment [COORD {C1 0.228, C2 1.3}, COORD {C1 0.158, C2 1.568}, COORD {C1 0.158, C2 0.5}, COORD {C1 0.228, C2 1.3}]}}}}]}",
 	            			iomGeom.toString());
 	            }
 	            rs.close();
@@ -1650,7 +1650,7 @@ public class GeoPackageWriterTest {
 	            rs = stmt.executeQuery("SELECT attrmultipolygon2, attr1mpg, attr2mpg FROM multipolygon_2");
 	            while (rs.next()) {
 	            	IomObject iomGeom = gpkg2iox.read(rs.getBytes(1));
-	            	assertEquals("MULTISURFACE {surface [SURFACE {boundary BOUNDARY {polyline POLYLINE {sequence SEGMENTS {segment [COORD {C1 -0.228, C2 0.568}, COORD {C1 -0.158, C2 0.568}, COORD {C1 -0.158, C2 0.568}, COORD {C1 -0.158, C2 0.588}, COORD {C1 -0.158, C2 0.588}, COORD {C1 -0.228, C2 0.568}]}}}}, SURFACE {boundary BOUNDARY {polyline POLYLINE {sequence SEGMENTS {segment [COORD {C1 0.228, C2 1.3}, COORD {C1 0.158, C2 1.568}, COORD {C1 0.158, C2 1.568}, COORD {C1 0.158, C2 0.5}, COORD {C1 0.158, C2 0.5}, COORD {C1 0.228, C2 1.3}]}}}}]}",
+	            	assertEquals("MULTISURFACE {surface [SURFACE {boundary BOUNDARY {polyline POLYLINE {sequence SEGMENTS {segment [COORD {C1 -0.228, C2 0.568}, COORD {C1 -0.158, C2 0.568}, COORD {C1 -0.158, C2 0.588}, COORD {C1 -0.228, C2 0.568}]}}}}, SURFACE {boundary BOUNDARY {polyline POLYLINE {sequence SEGMENTS {segment [COORD {C1 0.228, C2 1.3}, COORD {C1 0.158, C2 1.568}, COORD {C1 0.158, C2 0.5}, COORD {C1 0.228, C2 1.3}]}}}}]}",
 	            			iomGeom.toString());
 	            	assertEquals("text3", rs.getString(2));
 	            	assertEquals("8", rs.getString(3));	            	


### PR DESCRIPTION
Der JsonReader wurde zu Zeiten von ili23 geschrieben und er konnte keine Json-Arrays mit einfachen Datentypen lesen. Mit ili24 gibt es dazu das Äquivalent in der Sprache. Ich benötige die Unterstützung für einen JsonValidator-Task in GRETL und möchte nicht Array in Json schreiben, die immer aus einer Struktur (aus einem Json-Objekt) bestehen.

Der Pull-Request beinhaltet:

- Das Update der Basisbibliotheken auf die "Januar"-Versionen. 
- Die Unterstützung des JsonReaders für Arrays mit einfachen Datentypen.

Ich dachte, ich bräuchte die aktuellsten ili2db-Version wegen Json2Iox etc. War aber nicht der Fall. Falls ich einen separaten Pullrequest machen soll (für das Update), kann ich das machen. Das Update hatte zur Folge, dass ein paar Tests angepasst werden mussten. Die IomObject.toString() Methode liefert zwar gleiche Koordinatenwerte aber in der alten Version wurden immer die Stützpunkte wiederholt.

Die Array-Unterstützung ist in der JsonReader-Klasse. Zusätzlich wurde noch "ret.setobjectline(lineNumber);" implementiert.

Der Vollständigkeit halber wollte ich auch noch den Writer machen. Da bin ich der Meinung, dass man die Iox2Json.write() Methode in ili2db anpassen sollte.